### PR TITLE
Update battery_alert.yaml

### DIFF
--- a/packages/battery_alert.yaml
+++ b/packages/battery_alert.yaml
@@ -607,7 +607,7 @@ automation:
               ) and (
                 item.attributes.icon is not defined
               ) and (
-                not is_state_attr(entity_id, 'battery_alert_disabled', true)
+                not is_state_attr(item.entity_id, 'battery_alert_disabled', true)
               )
             )
           -%}


### PR DESCRIPTION
Without the `item.` added to line 610's `entity_id` throws `Error rendering template: UndefinedError: 'entity_id' is undefined` and is unable to update Battery Status group.