### PR TITLE
Update battery_alert.yaml

### DIFF
--- a/packages/battery_alert.yaml
+++ b/packages/battery_alert.yaml
@@ -256,6 +256,7 @@
 ################################################
 homeassistant:
   customize:
+
     ################################################
     ## Node Anchors
     ################################################
@@ -598,6 +599,8 @@ automation:
           value_template: "{{ trigger.event.data.new_state.attributes.battery is defined }}"
         - condition: template
           value_template: "{{ trigger.event.data.new_state.attributes['Battery numeric'] is defined }}"
+        - condition: template
+          value_template: "{{ trigger.event.data.new_state.attributes.battery_critical is defined }}"
   action:
     - service: mqtt.publish
       data_template:
@@ -614,6 +617,9 @@ automation:
             {%- elif trigger.event.data.new_state.attributes['Battery numeric'] is defined -%}
               {%- set attribval = (trigger.event.data.new_state.attributes['Battery numeric'] | int + 1) * 10 -%}
               {%- set attribname = 'Battery numeric' -%}
+            {% elif trigger.event.data.new_state.attributes.battery_critical is defined -%}
+              {%- set attribval = trigger.event.data.new_state.attributes.battery_critical -%}
+              {%- set attribname = 'Battery critical' -%}
             {%- endif -%}
             "name": "{{ trigger.event.data.new_state.name }} Battery",
             "state_topic": "homeassistant/sensor/{{ trigger.event.data.entity_id.split('.')[1] }}_battery/state",
@@ -624,6 +630,9 @@ automation:
             {% elif trigger.event.data.new_state.attributes.battery_template_string is defined -%}
             "value_template": "{{ trigger.event.data.new_state.attributes.battery_template_string }}",
             "icon": "mdi:battery",
+            {% elif trigger.event.data.new_state.attributes.battery_critical is defined -%}
+              "value_template": "{{ "{%" }} if value_json.value {{ "%}" }} low {{ "{%" }} else {{ "%}" }} full {{ "{%" }} endif {{ "%}" }}",
+              "icon": "mdi:battery",
             {% else -%}
             "value_template": "{{ "{{" }} value_json.value | int {{ "}}" }}",
             {% if attribval | int == attribval or attribval | float == attribval or attribval | length == attribval | float | string | length or attribval | length == attribval | int | string | length -%}
@@ -654,11 +663,13 @@ automation:
               {%- set attribval = trigger.event.data.new_state.attributes.battery -%}
             {%- elif trigger.event.data.new_state.attributes['Battery numeric'] is defined -%}
               {%- set attribval = (trigger.event.data.new_state.attributes['Battery numeric'] | int + 1) * 10 -%}
+            {%- elif trigger.event.data.new_state.attributes.battery_critical is defined -%}
+              {%- set attribval = trigger.event.data.new_state.attributes.battery_critical -%}
             {%- endif -%}
             "value": {% if attribval | int == attribval -%}
-              {{ attribval }}
+              {{ attribval | int }}
             {%- elif attribval | float == attribval -%}
-              {{ attribval }}
+              {{ attribval | float }}
             {%- elif attribval | length == attribval | float | string | length -%}
               {{ attribval | float }}
             {%- elif attribval | length == attribval | int | string | length -%}
@@ -682,6 +693,9 @@ automation:
             {%- elif trigger.event.data.new_state.attributes['Battery numeric'] is defined -%}
               {%- set attribval = (trigger.event.data.new_state.attributes['Battery numeric'] | int + 1) * 10 -%}
               {%- set attribname = 'Battery numeric' -%}
+            {%- elif trigger.event.data.new_state.attributes.battery_critical is defined -%}
+              {%- set attribval = trigger.event.data.new_state.attributes.battery_critical -%}
+              {%- set attribname = 'Battery critical' -%}
             {%- endif -%}
             "entity_id": "{{ trigger.event.data.entity_id }}",
             {% if attribname is defined -%}


### PR DESCRIPTION
Integrate support for devices with battery_critical attributes.
It is set to true when batteries are to be changed.