### PR TITLE
control and view are deprecated

### DIFF
--- a/packages/battery_alert.yaml
+++ b/packages/battery_alert.yaml
@@ -292,13 +292,11 @@ homeassistant:
       <<: *customize
       friendly_name: "Battery Alert"
       icon: mdi:steam
-      control: hidden
 
     group.battery_status:
       <<: *customize
       friendly_name: "Battery Status"
       icon: mdi:battery-charging
-      control: hidden
 
     ################################################
     ## Automation
@@ -343,13 +341,11 @@ homeassistant:
 ################################################
 group:
   battery_view:
-    view: yes
     entities:
       - group.battery_status
       - group.battery_alert
 
   battery_alert:
-    control: hidden
     entities:
       - input_boolean.low_batteries
       - input_number.battery_alert_threshold_min


### PR DESCRIPTION
control and view were used in the states ui (which is also deprecated in ha 0.105)

Relevant info:

The 'control' option (with value 'hidden') is deprecated, please remove it from your configuration. This option will become invalid in version 0.107.0
The 'view' option (with value 'True') is deprecated, please remove it from your configuration. This option will become invalid in version 0.107.0


Just removed the offending lines and did a quick testrun.
Some groups might be able to be removed  (battery_view) but I'm not sure.